### PR TITLE
This allows you to manage symbol keys

### DIFF
--- a/examples/json.pp
+++ b/examples/json.pp
@@ -1,0 +1,27 @@
+$data = {
+  "bar" => {
+    "baz" => "foo",
+    "moo" => 1,
+    "cow" => "1",
+  }
+}
+
+
+$symbols = {
+  ":bar" => {
+    "baz" => "foo",
+    "moo" => 1,
+    ":cow" => "1",
+  }
+}
+
+
+hash_file { '/tmp/hash.json':
+  value    => $data,
+  provider => 'json',
+}
+
+hash_file { '/tmp/symbols.json':
+  value    => $symbols,
+  provider => 'json',
+}

--- a/examples/yaml.pp
+++ b/examples/yaml.pp
@@ -1,0 +1,27 @@
+$data = {
+  "bar" => {
+    "baz" => "foo",
+    "moo" => 1,
+    "cow" => "1",
+  }
+}
+
+
+$symbols = {
+  ":bar" => {
+    "baz" => "foo",
+    "moo" => 1,
+    ":cow" => "1",
+  }
+}
+
+
+hash_file { '/tmp/hash.yaml':
+  value    => $data,
+  provider => 'yaml',
+}
+
+hash_file { '/tmp/symbols.yaml':
+  value    => $symbols,
+  provider => 'yaml',
+}

--- a/lib/puppet/type/hash_file.rb
+++ b/lib/puppet/type/hash_file.rb
@@ -16,6 +16,27 @@ Puppet::Type.newtype(:hash_file) do
         raise ArgumentError, "Value is not of type Hash"
       end
     end
+
+    # convert strings like ":thing" to a symbolic representation, :thing
+    # This is needed to manage symbol keys in yaml files.
+    munge do |value|
+      return value unless resource[:provider] == :yaml
+      resource.symbolize_keys(value)
+    end
+  end
+
+  def symbolize_keys(data)
+    data.each_with_object({}) do |item, memo|
+      key, val = item
+
+      val = symbolize_keys(val) if val.class == Hash
+
+      if key =~ /^:/
+        memo[key[1..-1].to_sym] = val
+      else
+        memo[key] = val
+      end
+    end
   end
 
 end


### PR DESCRIPTION
Given a hash like

``` puppet
$symbols = {
  ":bar" => {
    "baz" => "foo",
    "moo" => 1,
    ":cow" => "1",
  }
}
```

Prior to this commit, this type would manage a hash with literal keys
with the colon in them and it was impossible to manage a hash with
symbolic keys. This commit will convert a string like `":thing"` to a
symbol, like `:thing` when managing yaml files.

Fixes #2
