### PR TITLE
Add support for multi-document yaml files

### DIFF
--- a/lib/puppet/type/hash_file.rb
+++ b/lib/puppet/type/hash_file.rb
@@ -8,7 +8,7 @@ Puppet::Type.newtype(:hash_file) do
     desc "the path of the file - manage this separately with a file resource if you care about permissions and stuff"
   end
 
-  newproperty(:value) do
+  newproperty(:value, :array_matching => :all) do
     desc "the value that hash should be"
     defaultto {}
     validate do |value|


### PR DESCRIPTION
Add a `yaml_multidoc` provider to generate multi-document yaml files.

I.e. the following snippet
```puppet
hash_file { 'multidoc.yaml':
    value => [
        {
            'a' => 'b',
        },
        {
            'c' => 'd',
        },
    ],
    provider => 'yaml_multidoc',
}
```
produces the following multi-document yaml file:
```yaml
---
a: b
---
c: d
```